### PR TITLE
Make flags that aren't in the flag dictionary not cause an error

### DIFF
--- a/src/thon_symbols/main.py
+++ b/src/thon_symbols/main.py
@@ -244,7 +244,7 @@ def from_cmdline():
     code = input('Code: ')
     flags = input('Flags: ')
     for f in flags:
-        code = {'s': 'ş', 'S': 'Ş', 'i': 'ï', 'I': 'Ï'}[f] + code
+        code = {'s': 'ş', 'S': 'Ş', 'i': 'ï', 'I': 'Ï'}.get(f, "") + code
     out = run(code)[0]
     print('\nOutput')
     print(out)


### PR DESCRIPTION
Just a little thing to make the experience a little nicer. Also, (and this is a discussion for another issue, but I'll briefly mention it here), having multiple copies of the same flag will append its corresponding code equivalent multiple times. Is that intended behaviour?